### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_test_python_3_12.yml
+++ b/.github/workflows/run_test_python_3_12.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Run Tests 3.12
 on:
   workflow_dispatch: # Allow manual triggers


### PR DESCRIPTION
Potential fix for [https://github.com/haihabi/PyNNcml/security/code-scanning/6](https://github.com/haihabi/PyNNcml/security/code-scanning/6)

To resolve the issue, add a `permissions` key to the workflow to explicitly define the least privileges required for the task. Since this is a test-running workflow, it is likely that only `contents: read` permissions are needed. This ensures that the `GITHUB_TOKEN` has minimal access while the workflow executes.

The `permissions` block will be added at the root level of the workflow, applying to all jobs unless overridden at the job level. This change is localized to the `.github/workflows/run_test_python_3_12.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
